### PR TITLE
fix: :bug: align minimap and map dir & align camera

### DIFF
--- a/src/engine/movement.c
+++ b/src/engine/movement.c
@@ -6,7 +6,7 @@
 
 static bool	is_collision_with_wall(t_world *world, const t_vec *pos)
 {
-	return (world->worldmap[(int)pos->x][(int)pos->y] > 0);
+	return (world->worldmap[(int)pos->y][(int)pos->x] > 0);
 }
 
 void	engine__try_move_player(t_engine *e, double x, double y)
@@ -25,8 +25,8 @@ void	engine__try_move_player(t_engine *e, double x, double y)
 // both camera direction and camera plane must be rotated
 void	engine__rotate_player(t_engine *e, double angle)
 {
-	vec__rotate_assign(&e->camera.dir, -1 * angle * e->rotspeed);
-	vec__rotate_assign(&e->camera.plane, -1 * angle * e->rotspeed);
+	vec__rotate_assign(&e->camera.dir, angle * e->rotspeed);
+	vec__rotate_assign(&e->camera.plane, angle * e->rotspeed);
 }
 
 void	engine__move_player(t_engine *e)

--- a/src/parser/map.c
+++ b/src/parser/map.c
@@ -12,7 +12,7 @@ static void	world__init(t_world *this, t_string_arr raw_map, t_sizevec map_size)
 
 	this->camera = (t_camera){
 		.pos = {UNSET, UNSET},
-		.dir = {0, 1},
+		.dir = {0, -1},
 		.plane = {0.66, 0},
 	};
 	this->world_height = map_size.height;
@@ -28,7 +28,7 @@ static void	world__init(t_world *this, t_string_arr raw_map, t_sizevec map_size)
 			this->worldmap[it.y][it.x]
 				= (raw_map[it.y][it.x] == MAPFMT__WALL);
 			if (mapformat__is_player(raw_map[it.y][it.x]))
-				this->camera.pos = (t_vec){it.y, it.x}; // FIXME: ADD doc and func for why y and x is inverted here
+				this->camera.pos = (t_vec){it.x, it.y}; // FIXME: ADD doc and func for why y and x is inverted here
 			// TODO: setup func for player position
 		}
 	}

--- a/src/renderer/dda__step.c
+++ b/src/renderer/dda__step.c
@@ -51,7 +51,7 @@ void	dda__advance_step(t_dda__step *step, t_ivec *map_pos, t_vec *delta_dist)
 
 bool	dda__is_ray_hit_wall(const t_ivec *pos, t_world *world)
 {
-	return (world->worldmap[pos->x][pos->y] > 0);
+	return (world->worldmap[pos->y][pos->x] > 0);
 }
 
 void	dda__advance_step_until_hit(t_dda__step *step,

--- a/src/renderer/init.c
+++ b/src/renderer/init.c
@@ -39,13 +39,13 @@ void	renderer__init__world_data(t_renderer *this)
 
 	world.world_width = 24;
 	world.world_height = 24;
-	world.worldmap = std__allocate(world.world_width, sizeof(int *));
+	world.worldmap = std__allocate(world.world_height, sizeof(int *));
 	i = -1;
-	while (++i < world.world_width)
+	while (++i < world.world_height)
 	{
-		world.worldmap[i] = std__allocate(world.world_height, sizeof(int));
+		world.worldmap[i] = std__allocate(world.world_width, sizeof(int));
 		j = -1;
-		while (++j < world.world_height)
+		while (++j < world.world_width)
 			world.worldmap[i][j] = g_worldmap[i][j];
 	}
 	this->world = world;

--- a/src/renderer/minimap.c
+++ b/src/renderer/minimap.c
@@ -10,7 +10,7 @@ int	renderer__draw_minimap_color(
 
 	if (ivec__is_equal(pos_map, player_pos))
 		color = COLOR__RED;
-	else if (this->world.worldmap[pos_map->x][pos_map->y])
+	else if (this->world.worldmap[pos_map->y][pos_map->x])
 		color = COLOR__GRAY;
 	else
 		color = COLOR__WHITE;
@@ -25,18 +25,18 @@ void	renderer__draw_minimap_at(
 	t_irange	map_range_x;
 	t_irange	map_range_y;
 
-	map_range_y = (t_irange){0, this->world.world_width};
-	map_range_x = (t_irange){0, this->world.world_height};
+	map_range_x = (t_irange){0, this->world.world_width};
+	map_range_y = (t_irange){0, this->world.world_height};
 	idx = (t_ivec){x_range.start - 1, y_range.start - 1};
-	while (++idx.x < x_range.end)
+	while (++idx.y < y_range.end)
 	{
-		idx.y = y_range.start - 1;
-		while (++idx.y < x_range.end)
+		idx.x = x_range.start - 1;
+		while (++idx.x < x_range.end)
 		{
 			pos_map = (t_ivec){
 				math__normalize(idx.x, x_range, map_range_x),
 				math__normalize(idx.y, y_range, map_range_y)};
-			this->buf[idx.x][idx.y]
+			this->buf[idx.y][idx.x]
 				= renderer__draw_minimap_color(this, &pos_map, &player_pos);
 		}
 	}


### PR DESCRIPTION
# Abstract

- Fixes #21 
- Fixes #22 

## Types of edition

(Please remove irrelevant tags)

- [x] Bug fix (not modifying existing features)
- [x] New feature (not modifying existing features)


# 테스트 결과

- [x] Compile succeed
- [x] Envr diff with 42-cluster


# Details

1.
Now when camera faces North, minimap also faces North.

2.
Camera now shows correct view, previous one is right-side left.

3.
Playable character now rotate correct direction, previous one is right-side left.
(It looks correct in previous one, because camera also was inverted !)

4.
Minimap shows correct map and correct position where playable character locates,
N, S, E, W, and player's x,y position, and player's direction are corrected.


Now all functional !

![Screenshot from 2022-04-22 13-02-10](https://user-images.githubusercontent.com/62825700/164596103-00ea8112-5e4f-4e5f-8b60-6cf22fca40ee.png)



# NOTICE

1. When you modify player's direction vector, you have to modify camera plane also !
Let's assume that
player direction vector A(0, -1)
camera plane vector B(0.66, 0)

It is not just enough that A and B are normal ! (A scalar product B is 0 == normal)

You have to align directions of both vector for : size of (A cross product B) > 0

example)
A(0, -1), B(0.66, 0) => OK ! A * B = 0, A x B > 0
A(-1, 0), B(0.66, 0) => KO ! A * B != 0
A(0, 1), B(0.66, 0) =? KO ! A x B < 0