### PR TITLE
fix: :bug: fix minimap size causing segfault (#33)

### DIFF
--- a/include/types__renderer.h
+++ b/include/types__renderer.h
@@ -59,7 +59,7 @@ typedef enum e_config
 {
 	WIDTH = 640,
 	HEIGHT = 480,
-	MINIMAP_SIZE = 4,
+	MINIMAP_PIX = 4,
 }	t_config;
 
 typedef enum e_sign

--- a/src/engine/run.c
+++ b/src/engine/run.c
@@ -1,3 +1,4 @@
+#include "flags.h"
 #include "engine.h"
 #include "mlx.h"
 #include "renderer.h"
@@ -11,7 +12,8 @@ void	engine__refresh(t_engine *this)
 
 	renderer = &this->renderer;
 	renderer__raycast(renderer, &this->camera);
-	renderer__draw_minimap(renderer, &this->camera);
+	if (BONUS)
+		renderer__draw_minimap(renderer, &this->camera);
 	renderer__draw_to_window(renderer);
 }
 
@@ -29,11 +31,8 @@ void	engine__set_movespeed(t_engine *this)
 	}
 }
 
-// TODO: remove sprintf
 int	engine__loop(t_engine *this)
 {
-	static char	pos[80];
-
 	if (this->inputhandler.is_exit)
 		engine__deinit(this);
 	else if (inputhandler__is_movement(&this->inputhandler))
@@ -41,12 +40,7 @@ int	engine__loop(t_engine *this)
 		engine__refresh(this);
 		engine__set_movespeed(this);
 		engine__move_player(this);
-		sprintf(pos, "X: %f Y: %f dir: %f, %f",
-			this->camera.pos.x, this->camera.pos.y,
-			this->camera.dir.x, this->camera.dir.y);
 	}
-	mlx_string_put(this->renderer.mlx, this->renderer.window, 0, 96 + 13,
-		0xFFFFFF, pos);
 	return (0);
 }
 

--- a/src/renderer/minimap.c
+++ b/src/renderer/minimap.c
@@ -46,12 +46,11 @@ void	renderer__draw_minimap_at(
 
 void	renderer__draw_minimap(t_renderer *this, t_camera *camera)
 {
-	t_ivec	pos;
+	const t_ivec	pos = camera__to_pos_at_map(camera);
+	const t_irange	xrange = (t_irange){
+		4, math__min(4 + MINIMAP_PIX * (this->world.world_width), WIDTH / 2)};
+	const t_irange	yrange = (t_irange){
+		4, math__min(4 + MINIMAP_PIX * (this->world.world_height), HEIGHT / 2)};
 
-	pos = camera__to_pos_at_map(camera);
-	renderer__draw_minimap_at(
-		this, pos,
-		(t_irange){MINIMAP_SIZE, MINIMAP_SIZE * (1 + this->world.world_width)},
-		(t_irange){MINIMAP_SIZE, MINIMAP_SIZE * (1 + this->world.world_height)}
-		);
+	renderer__draw_minimap_at(this, pos, xrange, yrange);
 }


### PR DESCRIPTION
# Abstract

![image](https://user-images.githubusercontent.com/54838975/165451768-8dccea2f-6d89-483f-9bee-efe91f6818f5.png)

limits minimap size to 1/2 of screen size, maximum
and disable minimap for mandatory

- Fixes #32
- Fixes #33 


## Types of edition

- [x] Bug fix (not modifying existing features)

# 테스트 결과

- [x] Compile succeed